### PR TITLE
Improve TypeScript typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -41,8 +41,8 @@ declare class BroadcastChannel<T = any> {
     onmessage: OnMessageHandler<T>;
 
     // not defined in the offical standard
-    addEventListener(type: EventType, OnMessageHandler): void;
-    removeEventListener(type: EventType, OnMessageHandler): void;
+    addEventListener(type: EventType, handler: OnMessageHandler<T>): void;
+    removeEventListener(type: EventType, handler: OnMessageHandler<T>): void;
 }
 
 export default BroadcastChannel;

--- a/leader-election/index.d.ts
+++ b/leader-election/index.d.ts
@@ -18,10 +18,12 @@ export declare class LeaderElector {
 
 }
 
-export function create(channel: BroadcastChannel, options?: LeaderElectionOptions): LeaderElector;
+type CreateFunction = (channel: BroadcastChannel, options?: LeaderElectionOptions) => LeaderElector;
+
+export const create: CreateFunction;
 
 declare const _default: {
-    create;
-}
+    create: CreateFunction,
+};
 
 export default _default;


### PR DESCRIPTION
I had some issues using the TypeScript typings with the noImplicitAny compiler option enabled:

```
[at-loader] ./node_modules/broadcast-channel/index.d.ts:44:39 
	TS7006: Parameter 'OnMessageHandler' implicitly has an 'any' type.

[at-loader] ./node_modules/broadcast-channel/index.d.ts:45:42 
	TS7006: Parameter 'OnMessageHandler' implicitly has an 'any' type.

[at-loader] ./node_modules/broadcast-channel/leader-election/index.d.ts:24:5 
	TS7008: Member 'create' implicitly has an 'any' type.
```