### PR TITLE
Correct package.json license to MIT (not ISC)

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "url": "git+https://github.com/pubkey/broadcast-channel.git"
   },
   "author": "pubkey",
-  "license": "ISC",
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/pubkey/broadcast-channel/issues"
   },


### PR DESCRIPTION
The LICENSE file presents MIT however the package.json says ISC. Probably because `npm init` defaults to ISC.

Whether this actually constitutes a "relicensing" of the project or not is debatable and I Am Not a Lawyer so can't say 😄 