### PR TITLE
fix: allow optimized bundling with fusebox

### DIFF
--- a/dist/es/method-chooser.js
+++ b/dist/es/method-chooser.js
@@ -6,7 +6,7 @@ import { isNode } from './util'; // order is important
 
 var METHODS = [NativeMethod, // fastest
 IndexeDbMethod, LocalstorageMethod, SimulateMethod];
-var REQUIRE_FUN = require;
+
 /**
  * The NodeMethod is loaded lazy
  * so it will not get bundled in browser-builds
@@ -17,7 +17,7 @@ if (isNode) {
    * we use the non-transpiled code for nodejs
    * because it runs faster
    */
-  var NodeMethod = REQUIRE_FUN('../../src/methods/node.js');
+  var NodeMethod = require('../../src/methods/node.js');
   /**
    * this will be false for webpackbuilds
    * which will shim the node-method with an empty object {}


### PR DESCRIPTION
Even with a custom build, `broadcast-channel` gets bundled, confusing `fuse-box` bundler in the process during it's optimization build unable to resolve these `var REQUIRE_FUN = require` statements.

If I understand this correctly, the current design has to do with deferring the require statement until it is actually needed (if it ever is).

My config is:

```
import RxDb from 'rxdb/plugins/core'
import RxDBNoValidateModule from 'rxdb/plugins/no-validate'
import RxDBEncryptionModule from 'rxdb/plugins/encryption'
import RxDBKeyCompressionModule from 'rxdb/plugins/key-compression'
import { RxDatabase, RxDatabaseCreator } from "rxdb/typings/rx-database"
import * as RxIdbAdapter from 'pouchdb-adapter-idb'

export class DatabaseService implements IDatabaseService {
  constructor() {
    RxDb.plugin(RxDBNoValidateModule)
    RxDb.plugin(RxDBEncryptionModule)
    RxDb.plugin(RxDBKeyCompressionModule)
    RxDb.plugin(RxIdbAdapter)
  }
```

The only way I can get this to bundle is by modifying the require statement in `method-chooser.js`
