### PR TITLE
Add ability to extend with custom methods

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -7,8 +7,20 @@ interface BroadcastChannelEventMap {
     "messageerror": MessageEvent;
 }
 
+export interface BroadcastMethod<State = object> {
+  type: string;
+  microSeconds(): number;
+  create(channelName: string, options: BroadcastChannelOptions): Promise<State> | State;
+  close(channelState: State): void;
+  onMessage(channelState: State, callback: (args: any) => void): void;
+  postMessage(channelState: State, message: any): Promise<any>;
+  canBeUsed(): boolean;
+  averageResponseTime(): number;
+}
+
 export type BroadcastChannelOptions = {
     type?: MethodType,
+    methods?: BroadcastMethod[] | BroadcastMethod,
     webWorkerSupport?: boolean;
     prepareDelay?: number;
     node?: {

--- a/src/method-chooser.js
+++ b/src/method-chooser.js
@@ -43,13 +43,15 @@ if (isNode) {
 
 
 export function chooseMethod(options) {
+    let chooseMethods = [].concat(options.methods, METHODS).filter(Boolean);
+
     // directly chosen
     if (options.type) {
         if (options.type === 'simulate') {
             // only use simulate-method if directly chosen
             return SimulateMethod;
         }
-        const ret = METHODS.find(m => m.type === options.type);
+        const ret = chooseMethods.find(m => m.type === options.type);
         if (!ret) throw new Error('method-type ' + options.type + ' not found');
         else return ret;
     }
@@ -58,9 +60,8 @@ export function chooseMethod(options) {
      * if no webworker support is needed,
      * remove idb from the list so that localstorage is been chosen
      */
-    let chooseMethods = METHODS;
     if (!options.webWorkerSupport && !isNode) {
-        chooseMethods = METHODS.filter(m => m.type !== 'idb');
+        chooseMethods = chooseMethods.filter(m => m.type !== 'idb');
     }
 
     const useMethod = chooseMethods.find(method => method.canBeUsed());

--- a/src/options.js
+++ b/src/options.js
@@ -1,6 +1,5 @@
-export function fillOptionsWithDefaults(options) {
-    if(!options) options = {};
-    options = JSON.parse(JSON.stringify(options));
+export function fillOptionsWithDefaults(originalOptions = {}) {
+    const options = JSON.parse(JSON.stringify(originalOptions));
 
     // main
     if (typeof options.webWorkerSupport === 'undefined') options.webWorkerSupport = true;
@@ -15,6 +14,9 @@ export function fillOptionsWithDefaults(options) {
     // localstorage
     if (!options.localstorage) options.localstorage = {};
     if (!options.localstorage.removeTimeout) options.localstorage.removeTimeout = 1000 * 60;
+
+    // custom methods
+    if (originalOptions.methods) options.methods = originalOptions.methods;
 
     // node
     if (!options.node) options.node = {};

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -1,4 +1,5 @@
 require('./unit/oblivious-set.test.js');
+require('./unit/custom.method.test');
 require('./unit/node.method.test.js');
 require('./unit/native.method.test.js');
 require('./unit/indexed-db.method.test.js');

--- a/test/unit/custom.method.test.js
+++ b/test/unit/custom.method.test.js
@@ -1,0 +1,28 @@
+const AsyncTestUtil = require('async-test-util');
+const assert = require('assert');
+const BroadcastChannel = require('../../');
+
+describe('unit/custom.method.test.js', () => {
+    describe('custom methods', () => {
+        it('should select provided method', () => {
+            const channelName = AsyncTestUtil.randomString(12);
+            const method = {
+                type: 'custom',
+                canBeUsed: () => true,
+                create: () => ({})
+            };
+            const channel = new BroadcastChannel(channelName, { methods: method });
+            assert.equal(channel.method, method);
+        });
+        it('should select one of the provided methods', () => {
+            const channelName = AsyncTestUtil.randomString(12);
+            const method = {
+                type: 'custom',
+                canBeUsed: () => true,
+                create: () => ({})
+            };
+            const channel = new BroadcastChannel(channelName, { methods: [method] });
+            assert.equal(channel.method, method);
+        });
+    });
+});


### PR DESCRIPTION
Hello!

First of all, I would like to thank you for this brilliant package. It solves many of our problems with the leader election.

In this PR I want to extend the current functionality of the method chooser so that we could provide our custom transports. In our business case, we already have the preferred data-transport mechanism. And it would be nice if we could use it as one of possibe methods.

Hope that I didn't mess up with test files structure and added my tests to the right place.