### PR TITLE
Fix for #68

### DIFF
--- a/types/broadcast-channel.d.ts
+++ b/types/broadcast-channel.d.ts
@@ -33,7 +33,7 @@ export type BroadcastChannelOptions = {
     };
 };
 
-declare type EventType = 'message' | 'error' | 'internal';
+declare type EventType = 'message' | 'internal';
 
 declare type OnMessageHandler<T> = ((this: BroadcastChannel, ev: T) => any) | null;
 


### PR DESCRIPTION
This has two changes to address #68

- First commit just removes `'error'` from `EventType` in the ts file
- ~~Second commit adds event type validation (+ tests) for `addEventListener` and `removeEventListener`~~

Edit: I rolled my PR branch back one commit and force pushed it, so now this just updates the ts file.