### PR TITLE
Differentiate Node from Electron Browser

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -49,7 +49,6 @@ export function microSeconds() {
     }
 }
 
-
 /**
  * copied from the 'detect-node' npm module
  * We cannot use the module directly because it causes problems with rollup

--- a/src/util.js
+++ b/src/util.js
@@ -49,9 +49,15 @@ export function microSeconds() {
     }
 }
 
+
 /**
  * copied from the 'detect-node' npm module
  * We cannot use the module directly because it causes problems with rollup
  * @link https://github.com/iliakan/detect-node/blob/master/index.js
  */
-export const isNode = Object.prototype.toString.call(typeof process !== 'undefined' ? process : 0) === '[object process]';
+export const isNodeOrElectron = Object.prototype.toString.call(typeof process !== 'undefined' ? process : 0) === '[object process]';
+
+const versions = isNodeOrElectron && process.versions;
+export const isElectronBrowser = versions && versions.electron && versions.chrome;
+
+export const isNode = isNodeOrElectron && !isElectronBrowser;


### PR DESCRIPTION
On my current project, we use Electron and we get errors when trying to use it with type='localstorage' option because the `process` object exists in Electron's BrowserWindow, so it is needed to dig a bit deeper :)