### PR TITLE
Handle IndexedDB onclose events.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
   <br/>
   <span>+ LeaderElection over the channels</span><br />
 </p>
- 
+
 <p align="center">
     <a href="https://twitter.com/pubkeypubkey">
         <img src="https://img.shields.io/twitter/follow/pubkeypubkey.svg?style=social&logo=twitter"
@@ -134,6 +134,35 @@ before(async () => {
 })
 ```
 
+#### Handling IndexedDB onclose events
+
+IndexedDB databases can close unexpectedly for various reasons. This could happen, for example, if the underlying storage is removed or if the user clears the database in the browser's history preferences. Most often we have seen this happen in Mobile Safari. By default, we let the connection close and stop polling for changes. If you would like to continue listening you should close BroadcastChannel and create a new one.
+
+Example of how you might do this:
+
+```typescript
+const { BroadcastChannel } = require('broadcast-channel');
+
+let channel;
+
+const createChannel = () => {
+  channel = new BroadcastChannel(CHANNEL_NAME, {
+    idb: {
+      onclose: () => {
+        // the onclose event is just the IndexedDB closing.
+        // you should also close the channel before creating
+        // a new one.
+        channel.close();
+        createChannel();
+      },
+    },
+  });
+
+  channel.onmessage = message => {
+    // handle message
+  };
+};
+```
 
 ## Methods:
 

--- a/src/methods/indexed-db.js
+++ b/src/methods/indexed-db.js
@@ -183,6 +183,18 @@ export function create(channelName, options) {
         };
 
         /**
+         * Handle abrupt closes that do not originate from db.close().
+         * This could happen, for example, if the underlying storage is
+         * removed or if the user clears the database in the browser's
+         * history preferences.
+         */
+        db.onclose = function () {
+            state.closed = true;
+
+            if (options.idb.onclose) options.idb.onclose();
+        };
+
+        /**
          * if service-workers are used,
          * we have no 'storage'-event if they post a message,
          * therefore we also have to set an interval

--- a/src/options.js
+++ b/src/options.js
@@ -10,6 +10,9 @@ export function fillOptionsWithDefaults(originalOptions = {}) {
     //  after this time the messages get deleted
     if (!options.idb.ttl) options.idb.ttl = 1000 * 45;
     if (!options.idb.fallbackInterval) options.idb.fallbackInterval = 150;
+    //  handles abrupt db onclose events.
+    if (originalOptions.idb && typeof originalOptions.idb.onclose === 'function')
+        options.idb.onclose = originalOptions.idb.onclose;
 
     // localstorage
     if (!options.localstorage) options.localstorage = {};
@@ -21,7 +24,7 @@ export function fillOptionsWithDefaults(originalOptions = {}) {
     // node
     if (!options.node) options.node = {};
     if (!options.node.ttl) options.node.ttl = 1000 * 60 * 2; // 2 minutes;
-    if(typeof options.node.useFastPath === 'undefined') options.node.useFastPath = true;
+    if (typeof options.node.useFastPath === 'undefined') options.node.useFastPath = true;
 
     return options;
 }

--- a/test/unit/indexed-db.method.test.js
+++ b/test/unit/indexed-db.method.test.js
@@ -152,6 +152,21 @@ describe('unit/indexed-db.method.test.js', () => {
                 await IndexedDbMethod.close(channelState1);
                 await IndexedDbMethod.close(channelState2);
             });
+            it('should handle close events', async () => {
+                let callbackCount = 0;
+                const channelName = AsyncTestUtil.randomString(10);
+                const channelState = await IndexedDbMethod.create(channelName, {
+                    idb: {
+                        onclose: () => callbackCount++,
+                    }
+                });
+                assert.ok(channelState);
+
+                // The `onclose` event is not fired if the database connection is closed normally using `IDBDatabase.close()`
+                channelState.db.dispatchEvent(new Event('close'));
+                assert.equal(callbackCount, 1);
+                IndexedDbMethod.close(channelState);
+            });
         });
         describe('.postMessage()', () => {
             it('should not crash', async () => {

--- a/types/broadcast-channel.d.ts
+++ b/types/broadcast-channel.d.ts
@@ -30,6 +30,7 @@ export type BroadcastChannelOptions = {
     idb?: {
         ttl?: number;
         fallbackInterval?: number;
+        onclose?: () => void;
     };
 };
 


### PR DESCRIPTION
Related to this Issue: https://github.com/pubkey/broadcast-channel/issues/28

I am getting the following error from Mobile Safari browsers coming through Bugsnag:

```
Failed to execute 'transaction' on 'IDBDatabase': The database connection is closing.

node_modules/broadcast-channel/dist/es/methods/indexed-db.js:11:22 readNewMessages	
node_modules/broadcast-channel/dist/es/methods/indexed-db.js:186:18 _readLoop	
```

## Solution

Listen for IDB [onclose](https://developer.mozilla.org/en-US/docs/Web/API/IDBDatabase/close_event) events. When this occurs, stop polling for new changes and provide a callback so consumers can handle this event and re-establish a connection if they want.