### PR TITLE
Added Jest test and tweaked babel config a bit to make it work

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,9 +1,10 @@
 let presets = [
     [
-        '@babel/env',
+        '@babel/preset-env',
         {
-            loose: true,
-            modules: false
+            targets: {
+                node: 'current'
+            }
         }
     ]
 ];

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "eslint": "7.12.1",
     "gzip-size-cli": "3.0.0",
     "http-server": "0.12.3",
+    "jest": "^26.4.2",
     "karma": "5.2.3",
     "karma-babel-preprocessor": "8.0.1",
     "karma-browserify": "7.0.0",

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,3 +1,4 @@
 env:
     node: true
     mocha: true
+    jest: true

--- a/test/close.test.js
+++ b/test/close.test.js
@@ -1,0 +1,32 @@
+import BroadcastChannel from 'broadcast-channel';
+
+class Foo {
+    constructor () {
+        this.bc = new BroadcastChannel.BroadcastChannel('test');
+        this.bc.addEventListener('message', this.cb);
+    }
+
+    cb () {}
+}
+
+
+describe('Broadcast Channel', () => {
+    beforeEach(async () => {
+        await BroadcastChannel.clearNodeFolder();
+    });
+
+    test('local', async () => {
+        const foo = new Foo();
+
+        const result = await new Promise((a) => {
+            setTimeout(() => {
+                a(true);
+            }, 1000);
+        });
+
+        expect(result).toBe(true);
+
+        // Cleanup
+        await foo.bc.close();
+    });
+});


### PR DESCRIPTION
Added a very simple test in `close.test.js` that exemplifies the issue. I don't know about mocha or Karma but Jest is what I'm using and that's where I have the issue. I added the jest package to dev dependencies and also tweaked the babel config a bit to make Jest work. If you run the test using the command line e.g. `jest close` you will get a warning stating that

> Jest did not exit one second after the test run has completed.
> 
> This usually means that there are asynchronous operations that weren't stopped in your tests. Consider running Jest with `--detectOpenHandles` to troubleshoot this issue.

Same if you run them using WebStorm's Jest test runner, for example.