### PR TITLE
Upgrade detect-node

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
   ],
   "dependencies": {
     "@babel/runtime": "^7.7.2",
-    "detect-node": "^2.0.4",
+    "detect-node": "^2.1.0",
     "js-sha3": "0.8.0",
     "microseconds": "0.2.0",
     "nano-time": "1.0.0",


### PR DESCRIPTION
This will make it so that all the dependencies for the ESM version also offer an ESM version. `detect-node` is causing issues with `svelte-query` https://github.com/SvelteStack/svelte-query/issues/22