### PR TITLE
Remove dead Babel plugin

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -43,9 +43,6 @@ const plugins = [
     }],
     '@babel/transform-sticky-regex',
     '@babel/transform-unicode-regex',
-    '@babel/check-constants', ['@babel/transform-spread', {
-        'loose': true
-    }],
     '@babel/transform-parameters', ['@babel/transform-destructuring', {
         'loose': true
     }],

--- a/package.json
+++ b/package.json
@@ -75,7 +75,6 @@
   "devDependencies": {
     "@babel/cli": "7.13.16",
     "@babel/core": "7.14.2",
-    "@babel/plugin-check-constants": "7.0.0-beta.38",
     "@babel/plugin-proposal-object-rest-spread": "7.14.2",
     "@babel/plugin-transform-member-expression-literals": "7.12.13",
     "@babel/plugin-transform-property-literals": "7.12.13",


### PR DESCRIPTION
See https://github.com/pubkey/broadcast-channel/issues/604

npm 7 gives the error:

```
npm ERR! Could not resolve dependency:
npm ERR! peer @babel/core@"7.0.0-beta.38" from @babel/plugin-check-constants@7.0.0-beta.38
npm ERR! node_modules/@babel/plugin-check-constants
npm ERR!   dev @babel/plugin-check-constants@"7.0.0-beta.38" from the root project
```