### PR TITLE
Cleanup package.json entry points

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
   "bugs": {
     "url": "https://github.com/pubkey/broadcast-channel/issues"
   },
-  "main": "./dist/lib/index.es5.js",
-  "jsnext:main": "./dist/es/index.js",
+  "browser": "./dist/lib/index.es5.js",
+  "main": "./dist/es/index.js",
   "module": "./dist/es/index.js",
   "sideEffects": false,
   "types": "./types/index.d.ts",


### PR DESCRIPTION
`jsnext:main` has been deprecated in favor of `module` so remove it
`browser` refers to the client-side entry point: https://docs.npmjs.com/cli/v7/configuring-npm/package-json#browser
`main` refers to the server-side entry point (in contrast to `browser`) and so can support more recent ES syntax