### PR TITLE
Handle browser code at build time (vs runtime)

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -4,7 +4,7 @@ const TerserPlugin = require('terser-webpack-plugin');
 
 module.exports = {
     mode: 'production',
-    entry: './dist/es/browserify.index.js',
+    entry: './dist/lib/browserify.index.js',
     optimization: {
         minimize: true,
         minimizer: [new TerserPlugin()]

--- a/package.json
+++ b/package.json
@@ -24,14 +24,14 @@
   "bugs": {
     "url": "https://github.com/pubkey/broadcast-channel/issues"
   },
-  "main": "./dist/lib/index.es5.js",
-  "jsnext:main": "./dist/es/index.js",
+  "main": "./dist/es5node/index.js",
   "module": "./dist/es/index.js",
+  "browser": "./dist/lib/index.es5.js",
   "sideEffects": false,
   "types": "./types/index.d.ts",
   "scripts": {
     "test": "echo \"RUN ALL:\" && npm run test:node && npm run test:browser && npm run test:e2e",
-    "test:node": "npm run build && mocha ./test/index.test.js -b --timeout 6000 --exit",
+    "test:node": "npm run build:es5node && mocha ./test/index.test.js -b --timeout 6000 --exit",
     "test:node:loop": "npm run test:node && npm run test:node:loop",
     "test:browser": "npm run build && karma start ./config/karma.conf.js --single-run",
     "test:e2e": "concurrently \"npm run docs:serve\" \"sleep 20 && testcafe -b && testcafe chrome -e test/e2e.test.js --hostname localhost\" --kill-others --success first",
@@ -46,7 +46,8 @@
     "lint": "eslint src test config",
     "clear": "rimraf -rf ./dist && rimraf -rf ./gen",
     "build:es6": "rimraf -rf dist/es && cross-env NODE_ENV=es6 babel src --out-dir dist/es",
-    "build:es5": "cross-env NODE_ENV=es5 babel src --out-dir dist/lib",
+    "build:es5node": "cross-env NODE_ENV=es5 babel src --out-dir dist/es5node",
+    "build:es5browser": "cross-env NODE_ENV=es5 babel src --out-dir dist/lib && grep -rl NodeMethod dist/lib/ | xargs sed -i 's/.*NodeMethod.*//'",
     "build:test": "cross-env NODE_ENV=es5 babel test --out-dir test_tmp",
     "build:index": "browserify test_tmp/scripts/index.js > docs/index.js",
     "build:browser": "browserify test_tmp/scripts/e2e.js > docs/e2e.js",
@@ -55,7 +56,7 @@
     "build:leader-iframe": "browserify test_tmp/scripts/leader-iframe.js > docs/leader-iframe.js",
     "build:lib-browser": "browserify dist/lib/browserify.index.js > dist/lib/browser.js",
     "build:lib-browser:min": "uglifyjs --compress --mangle --output dist/lib/browser.min.js -- dist/lib/browser.js",
-    "build": "npm run clear && concurrently \"npm run build:es6\" \"npm run build:es5\" \"npm run build:test\" && concurrently \"npm run build:index\" \"npm run build:browser\" \"npm run build:worker\" \"npm run build:iframe\" \"npm run build:leader-iframe\" && npm run build:lib-browser && npm run build:lib-browser:min",
+    "build": "npm run clear && concurrently \"npm run build:es6\" \"npm run build:es5node\" \"npm run build:es5browser\" \"npm run build:test\" && concurrently \"npm run build:index\" \"npm run build:browser\" \"npm run build:worker\" \"npm run build:iframe\" \"npm run build:leader-iframe\" && npm run build:lib-browser && npm run build:lib-browser:min",
     "build:min": "uglifyjs --compress --mangle --output dist/lib/browserify.min.js -- dist/lib/browserify.index.js",
     "docs:only": "http-server ./docs --silent",
     "docs:serve": "npm run build && echo \"Open http://localhost:8080/\" && npm run docs:only"
@@ -123,10 +124,5 @@
     "watchify": "4.0.0",
     "webpack": "5.45.1",
     "webpack-cli": "4.7.2"
-  },
-  "browser": {
-    "./src/methods/node.js": false,
-    "./dist/es/methods/node.js": false,
-    "./dist/lib/methods/node.js": false
   }
 }


### PR DESCRIPTION
Fixes https://github.com/pubkey/broadcast-channel/issues/636

I had to include https://github.com/pubkey/broadcast-channel/pull/678 in this PR to be able to get anything done. If you'd prefer to merge that one first, I can rebase this one afterwards to drop those changes out of this PR

`jsnext:main` has been deprecated in favor of `module` so remove it
`browser` refers to the client-side entry point: https://docs.npmjs.com/cli/v7/configuring-npm/package-json#browser
`main` has to not use `import` and also provide the Node method, so I had to create a new build for that

Calling Babel a bunch of times from `package.json` feels a bit messy to me compared to having a single Rollup config that can output different builds. Rollup would also allow us to use `@rollup/plugin-replace` instead of `sed` for removing the Node method. However, this is a bigger change, so didn't want to do that as part of this PR