### PR TITLE
Remove remaining require statements

### DIFF
--- a/src/method-chooser.js
+++ b/src/method-chooser.js
@@ -3,7 +3,7 @@ import IndexeDbMethod from './methods/indexed-db.js';
 import LocalstorageMethod from './methods/localstorage.js';
 import SimulateMethod from './methods/simulate.js';
 // the line below will be removed from es5/browser builds
-import * as NodeMethod from '../../src/methods/node.js'; // the non-transpiled code runs faster
+import * as NodeMethod from './methods/node.js';
 
 import {
     isNode

--- a/test/unit/node.method.test.js
+++ b/test/unit/node.method.test.js
@@ -7,7 +7,7 @@ describe('unit/node.method.test.js', () => {
      * do not run in browser-tests
      */
     if (!isNode) return;
-    const NodeMethod = require('../../src/methods/node.js');
+    const NodeMethod = require('../../dist/es5node/methods/node.js');
 
     it('init', () => {
         process.setMaxListeners(0);


### PR DESCRIPTION
Fixes https://github.com/pubkey/broadcast-channel/issues/690

I tried running 4.0.0 on SvelteKit / Vite and it didn't quite work. It doesn't like `require` and `import` statements mixed in the same module and it looks like I missed a couple last time around. I made these changes locally to fix it

This gets transpiled back to `require` statements in dist/es5node/methods/node.js, so shouldn't affect that version at all, but just the ESM version