### PR TITLE
Add exports field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     },
     "browser": {
       "default": "./dist/lib/index.es5.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "homepage": "https://github.com/pubkey/broadcast-channel#readme",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -2,6 +2,15 @@
   "name": "broadcast-channel",
   "version": "4.0.0",
   "description": "A BroadcastChannel that works in New Browsers, Old Browsers, WebWorkers and NodeJs",
+  "exports": {
+    "node": {
+      "import": "./dist/es/index.js",
+      "default": "./dist/es5node/index.js"
+    },
+    "browser": {
+      "default": "./dist/lib/index.es5.js"
+    }
+  },
   "homepage": "https://github.com/pubkey/broadcast-channel#readme",
   "keywords": [
     "broadcast-channel",


### PR DESCRIPTION
According to https://github.com/webpack/webpack/issues/4674#issuecomment-773040416, the `module` field can have overriding meaning: it can be Node ESMor Web ESM. To resolve this, a new [`exports`](https://webpack.js.org/guides/package-exports/) field in package.json is introduced, which is currently supported by Node.js, webpack, rollup, Vite, and others.