### PR TITLE
Webpack 5 Relative Import Support

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,13 +3,15 @@
   "version": "4.1.0",
   "description": "A BroadcastChannel that works in New Browsers, Old Browsers, WebWorkers and NodeJs",
   "exports": {
-    "node": {
-      "import": "./dist/esnode/index.js",
-      "default": "./dist/es5node/index.js"
-    },
-    "browser": {
-      "import": "./dist/esbrowser/index.js",
-      "default": "./dist/lib/index.es5.js"
+    ".": {
+      "node": {
+        "import": "./dist/esnode/index.js",
+        "default": "./dist/es5node/index.js"
+      },
+      "browser": {
+        "import": "./dist/esbrowser/index.js",
+        "default": "./dist/lib/index.es5.js"
+      }
     },
     "./package.json": "./package.json"
   },


### PR DESCRIPTION
This is a really simple fix to support the new package.json definition: https://nodejs.org/dist/latest-v14.x/docs/api/packages.html#packages_conditional_exports

```
Module not found: Error: Exports field key should be relative path and start with "." (key: "node")
```

Related to: https://github.com/pubkey/broadcast-channel/pull/704