### PR TITLE
ESM: use .js extension with type: module in package.json

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -57,15 +57,6 @@ if (process.env['NODE_ENV'] === 'es5') {
     ];
 }
 
-if (process.env['NODE_ENV'] === 'es6node') {
-    plugins.push([
-        'replace-import-extension',
-        {
-            'extMapping': { '.js': '.mjs' }
-        }
-    ]);
-}
-
 module.exports = {
     presets,
     plugins

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "exports": {
     ".": {
       "node": {
-        "import": "./dist/esnode/index.mjs",
+        "import": "./dist/esnode/index.js",
         "default": "./dist/es5node/index.js"
       },
       "browser": {
@@ -38,7 +38,7 @@
     "url": "https://github.com/pubkey/broadcast-channel/issues"
   },
   "main": "./dist/es5node/index.js",
-  "module": "./dist/esnode/index.mjs",
+  "module": "./dist/esnode/index.js",
   "browser": "./dist/lib/index.es5.js",
   "sideEffects": false,
   "types": "./types/index.d.ts",
@@ -61,8 +61,8 @@
     "size:rollup": "npm run build && rollup --config ./config/rollup.config.js && echo \"Build-Size Rollup (minified+gzip):\" && gzip-size --raw ./test_tmp/rollup.bundle.js",
     "lint": "eslint src test config --cache",
     "clear": "rimraf -rf ./dist && rimraf -rf ./gen",
-    "build:es6node": "rimraf -rf dist/esnode && cross-env NODE_ENV=es6node babel src --out-dir dist/esnode --out-file-extension .mjs",
-    "build:es6browser": "rimraf -rf dist/esbrowser && cross-env NODE_ENV=es6 babel src --out-dir dist/esbrowser && grep -rl NodeMethod dist/esbrowser/ | xargs sed -i 's/.*NodeMethod.*//'",
+    "build:es6node": "rimraf -rf dist/esnode && cross-env NODE_ENV=es6 babel src --out-dir dist/esnode && echo '{ \"type\": \"module\" }' > dist/esnode/package.json",
+    "build:es6browser": "rimraf -rf dist/esbrowser && cross-env NODE_ENV=es6 babel src --out-dir dist/esbrowser && grep -rl NodeMethod dist/esbrowser/ | xargs sed -i 's/.*NodeMethod.*//' && echo '{ \"type\": \"module\" }' > dist/esbrowser/package.json",
     "build:es5node": "cross-env NODE_ENV=es5 babel src --out-dir dist/es5node",
     "build:es5browser": "cross-env NODE_ENV=es5 babel src --out-dir dist/lib && grep -rl NodeMethod dist/lib/ | xargs sed -i 's/.*NodeMethod.*//'",
     "build:test": "cross-env NODE_ENV=es5 babel test --out-dir test_tmp",
@@ -104,7 +104,6 @@
     "@types/core-js": "2.5.5",
     "assert": "2.0.0",
     "async-test-util": "2.0.0",
-    "babel-plugin-replace-import-extension": "1.1.3",
     "browserify": "17.0.0",
     "child-process-promise": "2.2.1",
     "clone": "2.1.2",

--- a/test/module.esm.test.mjs
+++ b/test/module.esm.test.mjs
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import { BroadcastChannel } from '../dist/esnode/index.mjs';
+import { BroadcastChannel } from '../dist/esnode/index.js';
 
 describe('ESM module', () => {
     it('should import without error', () => {


### PR DESCRIPTION
Better way to fix ES module for Node.js and browser environments and also for using with Jest:
- Keep '.js' extension instead of '.mjs'
- Add small 'package.json' file to `dist/esnode` and `dist/esbrowser` with contents ```{ "type": "module" }```
- 
Without this change need to use `moduleNameMapper` in Jest config with entry:
```js
'^broadcast-channel$': '<rootDir>/node_modules/broadcast-channel/dist/esnode/index.mjs'
```