### PR TITLE
Fix broadcast-channel not receiving message from native BroadcastChannel

### DIFF
--- a/src/broadcast-channel.js
+++ b/src/broadcast-channel.js
@@ -247,7 +247,9 @@ function _startListening(channel) {
         // someone is listening, start subscribing
 
         const listenerFn = msgObj => {
-            channel._addEL[msgObj.type]
+            const isPlainMessage = typeof (msgObj) === "string";
+            const type = isPlainMessage ? "message" : msgObj.type;  
+            channel._addEL[type]
                 .forEach(listenerObject => {
                     /**
                      * Getting the current time in JavaScript has no good precision.
@@ -261,8 +263,8 @@ function _startListening(channel) {
                     const hundredMsInMicro = 100 * 1000;
                     const minMessageTime = listenerObject.time - hundredMsInMicro;
 
-                    if (msgObj.time >= minMessageTime) {
-                        listenerObject.fn(msgObj.data);
+                    if (isPlainMessage || msgObj.time >= minMessageTime) {
+                        listenerObject.fn(isPlainMessage ? msgObj : msgObj.data);
                     }
                 });
         };


### PR DESCRIPTION
@pubkey


## This PR contains:
 - A BUGFIX

## Describe the problem you have without this PR
When you have multiple tabs, some of them use "broadcast-channel" and some of them use native BroadcastChannel, there is a problem.
When native BroadcastChannel send a message, "broadcast-channel" expect an object, but in fact it receives just a plain string. I think this situation needs to be handled.
To handle this problem I propose checking "msgObj" type. If it is a string, pass it to listeners. When it is an object, handle it like it was before

