### PR TITLE
Fix renovate PR of rimraf 5.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "@babel/runtime": "7.22.6",
     "oblivious-set": "1.1.1",
     "p-queue": "6.6.2",
-    "rimraf": "3.0.2",
+    "rimraf": "5.0.1",
     "unload": "2.4.1"
   },
   "devDependencies": {

--- a/src/methods/node.js
+++ b/src/methods/node.js
@@ -10,7 +10,7 @@ import os from 'os';
 import events from 'events';
 import net from 'net';
 import path from 'path';
-import rimraf from 'rimraf';
+import { rimraf } from 'rimraf';
 import PQueue from 'p-queue';
 import {
     add as unloadAdd
@@ -47,7 +47,7 @@ const readFile = util.promisify(fs.readFile);
 const unlink = util.promisify(fs.unlink);
 const readdir = util.promisify(fs.readdir);
 const chmod = util.promisify(fs.chmod);
-const removeDir = util.promisify(rimraf);
+const removeDir = rimraf.rimraf;
 
 const OTHER_INSTANCES = {};
 const TMP_FOLDER_NAME = 'pubkey.bc';


### PR DESCRIPTION
<!-- 
  The maintainer disabled PR notifications for this repo
  to not get spammed by the renovate bot.
  Please always add @pubkey so that I can see your PR.
-->
@pubkey


## This PR contains: 
 - Fixed the renovate PR to update to rimraf 5.x.

## Describe the problem you have without this PR
The renovate PR for rimraf 5.x did not include changes for necessary for rimraf 5.x.  Specifically, rimraf [no longer uses a default export](https://github.com/isaacs/rimraf/blob/main/README.md). In rimraf v4.x, the function returns a Promise.  So, util.promisify is not needed.




