### PR TITLE
fix(typings): add a default export

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,10 @@
         "types": "./types/index.d.ts",
         "import": "./dist/esbrowser/index.js",
         "default": "./dist/lib/index.es5.js"
+      },
+      "default": {
+        "types": "./types/index.d.ts",
+        "default": "./dist/lib/index.es5.js"
       }
     },
     "./package.json": "./package.json"


### PR DESCRIPTION
@pubkey

## This PR contains:

- IMPROVED TYPESCRIPT SUPPORT

## Describe the problem you have without this PR
When setting the typescript config to `moduleResolution: node16 | nodenext | bundler`, TypeScript cannot resolve the types for `broadcast-channel`. This can be fixed by adding a default export.

Also please see excerpt from https://nodejs.org/api/packages.html#extensions-in-subpaths below

> When using environment branches, always include a "default" condition where possible. Providing a "default" condition ensures that any unknown JS environments are able to use this universal implementation, which helps avoid these JS environments from having to pretend to be existing environments in order to support packages with conditional exports. For this reason, using "node" and "default" condition branches is usually preferable to using "node" and "browser" condition branches.

## Todos <!-- REMOVE THIS BLOCK OR PARTS OF IT IF NOT NEEDED -->
- [ ] Tests
- [ ] Documentation
- [ ] Typings
- [ ] Changelog

### Reproduction
- Please see this codesandbox - https://codesandbox.io/s/broadcast-channel-wkzx7v?file=/src/index.ts
 
![image](https://github.com/pubkey/broadcast-channel/assets/6714127/7b94e950-6c5b-4b37-95c6-1d5e3422ad34)

