### PR TITLE
Enables rimraf renovate PR to 5.x by replacing rimraf with native fs rm

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,6 @@
     "@babel/runtime": "7.22.10",
     "oblivious-set": "1.1.1",
     "p-queue": "6.6.2",
-    "rimraf": "3.0.2",
     "unload": "2.4.1"
   },
   "devDependencies": {
@@ -139,6 +138,7 @@
     "pre-commit": "1.2.2",
     "random-int": "3.0.0",
     "random-token": "0.0.8",
+    "rimraf": "5.0.1",
     "rollup": "3.28.0",
     "@rollup/plugin-terser": "0.4.3",
     "testcafe": "3.1.0",

--- a/src/methods/node.js
+++ b/src/methods/node.js
@@ -10,7 +10,6 @@ import os from 'os';
 import events from 'events';
 import net from 'net';
 import path from 'path';
-import rimraf from 'rimraf';
 import PQueue from 'p-queue';
 import {
     add as unloadAdd
@@ -47,7 +46,21 @@ const readFile = util.promisify(fs.readFile);
 const unlink = util.promisify(fs.unlink);
 const readdir = util.promisify(fs.readdir);
 const chmod = util.promisify(fs.chmod);
-const removeDir = util.promisify(rimraf);
+const rmDir = util.promisify(fs.rm);
+
+const removeDir = async (p) => {
+    try {
+        return await rmDir(p,
+            {
+                recursive: true
+            }
+        );
+    } catch (err) {
+        if (err.code !== 'ENOENT') {
+            throw err;
+        }
+    }
+};
 
 const OTHER_INSTANCES = {};
 const TMP_FOLDER_NAME = 'pubkey.bc';


### PR DESCRIPTION
@pubkey

## This PR contains:
- Replaces usage of `rimraf` in code with equivalent native `fs` call to circumvent `browserify`'s incompatibility with `rimraf` 5.x and enable renovate PR
- Shifts `rimraf` to dev dependency

## Describe the problem you have without this PR
- Current version of `rimraf` contains a vuln, renovate PR and [this PR](https://github.com/pubkey/broadcast-channel/pull/1228) have been unable to bump to version 5.x because of `browserify` parsing issues
