### PR TITLE
chore(deps): update dependency reimref to v6.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -147,7 +147,7 @@
     "pre-commit": "1.2.2",
     "random-int": "3.0.0",
     "random-token": "0.0.8",
-    "rimraf": "5.0.5",
+    "rimraf": "6.0.1",
     "rollup": "4.6.0",
     "testcafe": "3.4.0",
     "ts-node": "10.9.2",


### PR DESCRIPTION
@pubkey

The old version of rimraf included glob < v9, which is not supported any more and prints warnings when installing. This version of rimraf does not support Node.js < 20 any more (which means it only supports Node.js versions that are currently supported).